### PR TITLE
[fix] Fix typo in the feature description

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -142,7 +142,7 @@ User Interface
 ----------
 * Ambient display
   * Wake screen for notifications
-  * Always show tiem and info (AOD)
+  * Always show time and info (AOD)
   * Always show when charging
   * Music ticker
   * Edge light


### PR DESCRIPTION
The MR fixes the typo 'tiem' to the correct spelling 'time'.